### PR TITLE
[Refactor] : 유저 정보 관련 페이지 Refactoring

### DIFF
--- a/bovo_client/src/components/myPageListMenu/MenuList.jsx
+++ b/bovo_client/src/components/myPageListMenu/MenuList.jsx
@@ -13,10 +13,10 @@ import styles from "./MenuList.module.css";
 import { Link } from "react-router-dom";
 
 const menuItem = [
-    { text: "내 프로필", icon: <AccountBoxIcon sx={{fontSize: "3rem"}} />, path: "/mypage/myprofile" },
-    { text: "독서 캘린더", icon: <EventIcon sx={{fontSize: "3rem"}} />, path: "/calendar" },
-    { text: "서비스 정보", icon: <InfoIcon sx={{fontSize: "3rem"}} />, path: "/mypage/service-info" },
-    { text: "로그 아웃", icon: <ExitToAppIcon sx={{fontSize: "3rem"}} />, path: "", action: "logout" },
+    { type: "link", text: "내 프로필", icon: <AccountBoxIcon sx={{fontSize: "3rem"}} />, path: "/mypage/myprofile" },
+    { type: "link", text: "독서 캘린더", icon: <EventIcon sx={{fontSize: "3rem"}} />, path: "/calendar" },
+    { type: "link", text: "서비스 정보", icon: <InfoIcon sx={{fontSize: "3rem"}} />, path: "/mypage/service-info" },
+    { type: "action", text: "로그 아웃", icon: <ExitToAppIcon sx={{fontSize: "3rem"}} />, action: "logout" },
 ];
 
 const MenuList = ({ onLogout }) => {
@@ -26,7 +26,7 @@ const MenuList = ({ onLogout }) => {
             sx={{ backgroundColor: "#E5F1FB", borderRadius: "1.625rem" }}
         >
             {menuItem.map((item, index) => (
-                item.action === "logout" ? (
+                item.type === "action" ? (
                     <ListItemButton 
                         key={index}
                         className={styles.menuBtn} 

--- a/bovo_client/src/components/myPageListMenu/MenuList.jsx
+++ b/bovo_client/src/components/myPageListMenu/MenuList.jsx
@@ -1,8 +1,4 @@
 import PropTypes from "prop-types";
-import AccountBoxIcon from "@mui/icons-material/AccountBox";
-import EventIcon from "@mui/icons-material/Event";
-import InfoIcon from "@mui/icons-material/Info";
-import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
@@ -11,13 +7,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import styles from "./MenuList.module.css";
 import { Link } from "react-router-dom";
-
-const menuItem = [
-    { type: "link", text: "내 프로필", icon: <AccountBoxIcon sx={{fontSize: "3rem"}} />, path: "/mypage/myprofile" },
-    { type: "link", text: "독서 캘린더", icon: <EventIcon sx={{fontSize: "3rem"}} />, path: "/calendar" },
-    { type: "link", text: "서비스 정보", icon: <InfoIcon sx={{fontSize: "3rem"}} />, path: "/mypage/service-info" },
-    { type: "action", text: "로그 아웃", icon: <ExitToAppIcon sx={{fontSize: "3rem"}} />, action: "logout" },
-];
+import menuItem from "../../constant/MenuItem";
 
 const MenuList = ({ onLogout }) => {
     return (

--- a/bovo_client/src/components/myPageListMenu/MenuList.jsx
+++ b/bovo_client/src/components/myPageListMenu/MenuList.jsx
@@ -25,10 +25,10 @@ const MenuList = ({ onLogout }) => {
             className={styles.menuListContainer} 
             sx={{ backgroundColor: "#E5F1FB", borderRadius: "1.625rem" }}
         >
-            {menuItem.map((item, index) => (
+            {menuItem.map((item) => (
                 item.type === "action" ? (
                     <ListItemButton 
-                        key={index}
+                        key={item.text}
                         className={styles.menuBtn} 
                         onClick={() => onLogout(true)}
                     >
@@ -45,7 +45,7 @@ const MenuList = ({ onLogout }) => {
                     </ListItemButton>
                 ) : (
                     <ListItemButton 
-                        key={index}
+                        key={item.text}
                         className={styles.menuBtn} 
                         component={Link} // Link로 감싸기
                         to={item.path} 

--- a/bovo_client/src/components/myProfile/profileInfoItem/ProfileInfoItem.jsx
+++ b/bovo_client/src/components/myProfile/profileInfoItem/ProfileInfoItem.jsx
@@ -11,16 +11,16 @@ const ProfileInfoItem = ({ title, content, src }) => {
             <Typography sx={{ fontSize: "1.75rem" }} fontWeight="bold">
                 {title}
             </Typography>
-            {content !== "" ? (
+            {content !== null ? (
                 <Typography sx={{ fontSize: "1.75rem", textAlign: "right" }}>
                     {content}
                 </Typography>
             ) : (
                 <Box className={styles.imgWrapper} sx={{ textAlign: "right" }}>
-                    {src === "NONE" ? (
-                        <WorkspacePremiumIcon sx={{ fontSize: "4rem", color: "#D9D9D9" }} />
-                    ) : (
+                    {src ? (
                         <img src={src} alt="독서 성과 이미지" className={styles.bedgeImg} />
+                    ) : (
+                        <WorkspacePremiumIcon sx={{ fontSize: "4rem", color: "#D9D9D9" }} />
                     )} 
                 </Box>
             )}
@@ -33,6 +33,6 @@ export default ProfileInfoItem;
 // props 타입 정의
 ProfileInfoItem.propTypes = {
     title: PropTypes.string.isRequired, 
-    content: PropTypes.string.isRequired,
-    src: PropTypes.string.isRequired
+    content: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    src: PropTypes.string
 };

--- a/bovo_client/src/components/quest/questBtn/QuestBtn.jsx
+++ b/bovo_client/src/components/quest/questBtn/QuestBtn.jsx
@@ -1,36 +1,37 @@
 import Button from '@mui/material/Button';
 import PropTypes from 'prop-types';
 import styles from './QuestBtn.module.css';
+import { QuestButtonStyle } from '../../../constant/QuestBtnStyle';
+
+// 버튼 스타일을 결정하는 헬퍼 함수
+const getButtonStyle = (isCompleted, currentCount) => {
+    if (isCompleted && currentCount === 7) return QuestButtonStyle.completeBtn;
+    if (!isCompleted && currentCount === 7) return QuestButtonStyle.confirmBtn;
+    return QuestButtonStyle.notAcquiredBtn;
+};
 
 const QuestBtn = ({ isCompleted, currentCount, onClick }) => {
-    let backgroundColor, color, text;
+    // 버튼 스타일과 텍스트 추출
+    const { btnSx, btnText, isNotConfirm } = getButtonStyle(isCompleted, currentCount);
 
-    if (isCompleted && currentCount === 7) {
-        backgroundColor = "#FFFFFF";
-        color = "#739CD4";
-        text = "퀘스트 달성";
-    } else if (!isCompleted && currentCount === 7) {
-        backgroundColor = "#739CD4";
-        color = "#FFFFFF";
-        text = "확인";
-    } else if (!isCompleted && currentCount !== 7) {
-        backgroundColor = "#E8F1F6";
-        color = "#8D90A0";
-        text = "미획득";
-    }
+    const handleClick = () => {
+        if (isNotConfirm) {
+            onClick(); // onClick이 설정되어 있을 경우 호출
+        }
+    };
 
     return (
         <Button
             className={styles.questBtn}
-            onClick={onClick}
+            onClick={handleClick}
             sx={{
                 borderRadius: "0.625rem",
-                backgroundColor: backgroundColor,
-                color: color,
                 fontSize: "1.25rem",
+                ...btnSx,
             }}
+            disabled={!isNotConfirm}
         >
-            {text}
+            {btnText}
         </Button>
     );
 };

--- a/bovo_client/src/components/quest/questList/QuestList.jsx
+++ b/bovo_client/src/components/quest/questList/QuestList.jsx
@@ -32,12 +32,10 @@ const QuestList = ({ quest }) => {
     const isCompleted = quest?.[mission.completedKey] === 7 ? true : false;
     const progress = isCompleted ? 100 : (currentCount / 7) * 100; // 7회 기준 진행률 계산
 
-    // 확인 버튼 클릭 시 데이터 요청
-     // ✅ 버튼 클릭 시 mutation 호출
-     const handleQuestButtonClick = () => {
-        if (!isCompleted && currentCount === 7 && !isMutating) {
-            increaseExpMutate();
-        }
+    // 확인 버튼 클릭 시 mutation 호출
+    const handleQuestButtonClick = () => {
+        if (isMutating) return;
+        increaseExpMutate();
     };
 
     return (

--- a/bovo_client/src/components/quest/questList/QuestList.jsx
+++ b/bovo_client/src/components/quest/questList/QuestList.jsx
@@ -7,6 +7,7 @@ import QuestBtn from '../questBtn/QuestBtn';
 import { increaseExp } from '../../../api/RewardService';
 import { useMutation } from '@tanstack/react-query';
 import { queryClient } from '../../../store/queryClient/queryClient';
+import { missionKeys } from '../../../constant/QuestList';
 
 const QuestList = ({ quest }) => {
 
@@ -23,54 +24,12 @@ const QuestList = ({ quest }) => {
         }
     });
 
-    // 미션 제목 반환
-    const getMissionTitle = (missionId) => {
-        switch (missionId) {
-            case 1:
-                return "출석";
-            case 2:
-                return "커뮤니티 참여";
-            case 3:
-                return "책 등록";
-            default:
-                return "독서 기록";
-        }
-    };
+    // 📌 mission 정보 가져오기
+    const mission = missionKeys[quest.mission_id] || {};
 
-    // 미션별 cnt 값 반환
-    const getMissionCount = (quest) => {
-        switch (quest.mission_id) {
-            case 1:
-                return quest.login_cnt;
-            case 2:
-                return quest.community_cnt;
-            case 3:
-                return quest.book_reg_cnt;
-            case 4:
-                return quest.note_cnt;
-            default:
-                return 0;
-        }
-    };
-
-    // 미션 완료 여부 반환
-    const isMissionCompleted = (quest) => {
-        switch (quest.mission_id) {
-            case 1:
-                return quest.is_login_completed;
-            case 2:
-                return quest.is_community_completed;
-            case 3:
-                return quest.is_book_reg_completed;
-            case 4:
-                return quest.is_note_completed;
-            default:
-                return false;
-        }
-    };
-
-    const currentCount = getMissionCount(quest);
-    const isCompleted = isMissionCompleted(quest);
+    const title = mission.title;
+    const currentCount = quest?.[mission.countKey];
+    const isCompleted = quest?.[mission.completedKey] === 7 ? true : false;
     const progress = isCompleted ? 100 : (currentCount / 7) * 100; // 7회 기준 진행률 계산
 
     // 확인 버튼 클릭 시 데이터 요청
@@ -88,7 +47,7 @@ const QuestList = ({ quest }) => {
                     sx={{fontSize: "1.75rem", display: "flex", alignItems: "center"}} 
                     fontWeight="bold"
                 >
-                    {getMissionTitle(quest.mission_id)} &nbsp;
+                    {title} &nbsp;
                 </Typography>
                 <Typography
                     sx={{

--- a/bovo_client/src/components/withdrawModal/WithdrawModal.jsx
+++ b/bovo_client/src/components/withdrawModal/WithdrawModal.jsx
@@ -6,10 +6,10 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import styles from './WithdrawModal.module.css';
 
-const WithdrawModal = ({open, onClose, handleWithdraw}) => {
+const WithdrawModal = ({isOpen, onClose, handleWithdraw}) => {
     return (
         <Dialog 
-            open={open} 
+            open={isOpen} 
             sx={{
                 "& .MuiDialog-paper": {
                     width: "41.25rem",               // 너비 변경
@@ -92,7 +92,7 @@ const WithdrawModal = ({open, onClose, handleWithdraw}) => {
 
 // props 타입 정의
 WithdrawModal.propTypes = {
-    open: PropTypes.func.isRequired, 
+    isOpen: PropTypes.bool.isRequired, 
     onClose: PropTypes.func.isRequired,
     handleWithdraw: PropTypes.func.isRequired
 };

--- a/bovo_client/src/components/withdrawModal/WithdrawModal.jsx
+++ b/bovo_client/src/components/withdrawModal/WithdrawModal.jsx
@@ -7,6 +7,17 @@ import DialogTitle from "@mui/material/DialogTitle";
 import styles from './WithdrawModal.module.css';
 
 const WithdrawModal = ({isOpen, onClose, handleWithdraw}) => {
+    // 회원탈퇴 modal btn관련 공통 style 선언
+    const btnSx = {
+        width: "12.5rem",
+        height: "5rem",
+        borderRadius: "1.5rem",
+        backgroundColor: "white",
+        fontSize: "2rem",
+        letterSpacing: "0",
+        textAlign: "center",
+    }
+
     return (
         <Dialog 
             open={isOpen} 
@@ -58,14 +69,8 @@ const WithdrawModal = ({isOpen, onClose, handleWithdraw}) => {
                 <Button 
                     onClick={onClose}
                     sx={{
-                        width: "12.5rem",
-                        height: "5rem",
-                        borderRadius: "1.5rem",
-                        backgroundColor: "white",
+                        ...btnSx,
                         color: "#739CD4",
-                        fontSize: "2rem",
-                        letterSpacing: "0",
-                        textAlign: "center",
                     }}  
                 >
                     취소
@@ -73,14 +78,8 @@ const WithdrawModal = ({isOpen, onClose, handleWithdraw}) => {
                 <Button 
                     onClick={handleWithdraw}
                     sx={{
-                        width: "12.5rem",
-                        height: "5rem",
-                        borderRadius: "1.5rem",
-                        backgroundColor: "white",
+                        ...btnSx,
                         color: "#FCA18D",
-                        fontSize: "2rem",
-                        letterSpacing: "0",
-                        textAlign: "center",
                     }} 
                 >
                     확인

--- a/bovo_client/src/constant/MenuItem.jsx
+++ b/bovo_client/src/constant/MenuItem.jsx
@@ -1,0 +1,13 @@
+import AccountBoxIcon from "@mui/icons-material/AccountBox";
+import EventIcon from "@mui/icons-material/Event";
+import InfoIcon from "@mui/icons-material/Info";
+import ExitToAppIcon from "@mui/icons-material/ExitToApp";
+
+const menuItem = [
+    { type: "link", text: "내 프로필", icon: <AccountBoxIcon sx={{fontSize: "3rem"}} />, path: "/mypage/myprofile" },
+    { type: "link", text: "독서 캘린더", icon: <EventIcon sx={{fontSize: "3rem"}} />, path: "/calendar" },
+    { type: "link", text: "서비스 정보", icon: <InfoIcon sx={{fontSize: "3rem"}} />, path: "/mypage/service-info" },
+    { type: "action", text: "로그 아웃", icon: <ExitToAppIcon sx={{fontSize: "3rem"}} />, action: "logout" },
+];
+
+export default menuItem;

--- a/bovo_client/src/constant/QuestBtnStyle.js
+++ b/bovo_client/src/constant/QuestBtnStyle.js
@@ -1,0 +1,26 @@
+export const QuestButtonStyle = {
+    completeBtn: {
+        btnSx: {
+            backgroundColor: "#FFFFFF",
+            color: "#739CD4",
+        },
+        btnText: "퀘스트 달성",
+        isNotConfirm: false,
+    },
+    confirmBtn: {
+        btnSx: {
+                backgroundColor: "#739CD4",
+                color: "#FFFFFF",
+        },
+        btnText: "확인",
+        isNotConfirm: true,
+    },
+    notAcquiredBtn: {
+        btnSx: {
+                backgroundColor: "#E8F1F6",
+                color: "#8D90A0",
+        },
+        btnText: "미획득",
+        isNotConfirm: false,
+    },
+};

--- a/bovo_client/src/constant/QuestList.js
+++ b/bovo_client/src/constant/QuestList.js
@@ -1,0 +1,22 @@
+export const missionKeys = {
+    1: {
+        title: "출석",
+        countKey: "login_cnt",
+        completedKey: "is_login_completed",
+    },
+    2: {
+        title: "커뮤니티 참여",
+        countKey: "community_cnt",
+        completedKey: "is_community_completed",
+    },
+    3: {
+        title: "책 등록",
+        countKey: "book_reg_cnt",
+        completedKey: "is_book_reg_completed",
+    },
+    4: {
+        title: "독서 기록",
+        countKey: "note_cnt",
+        completedKey: "is_note_completed",
+    },
+};

--- a/bovo_client/src/pages/exp/Exp.jsx
+++ b/bovo_client/src/pages/exp/Exp.jsx
@@ -8,6 +8,7 @@ import BedgeInfoModal from "../../components/bedgeInfoModal/BedgeInfoModal";
 import bedgeImages from "../../constant/BedgeImg";
 import { useRewardsQuery } from "../../api/RewardService";
 import QuestList from "../../components/quest/questList/QuestList";
+import LoadingSpinner from '../../components/loadingSpinner/LoadingSpinner';
 
 const Exp = () => {
     const [openQuestModal, setOpenQuestModal] = useState(false); // quest info 모달 상태 추가
@@ -25,25 +26,13 @@ const Exp = () => {
     }, [rewardData]);  // rewardData가 변경될 때만 실행
 
     // questInfoModal 관련 함수
-    const handleOpenQuestModal = () => {
-        setOpenQuestModal(true);
-    };
-
-    const handleCloseQuestModal = () => {
-        setOpenQuestModal(false);
-    };
+    const handleOpenQuestModal = (open) => setOpenQuestModal(open);
 
     // bedgeInfoModal 관련 함수
-    const handleOpenBedgeModal = () => {
-        setOpenBedgeModal(true);
-    };
-
-    const handleCloseBedgeModal = () => {
-        setOpenBedgeModal(false);
-    };
+    const handleOpenBedgeModal = (open) => setOpenBedgeModal(open);
 
     // 로딩 중 또는 에러 처리
-    if (isLoading) return <Typography>로딩 중...</Typography>;
+    if (isLoading) return <LoadingSpinner />;
     if (isError) return <Typography>데이터를 불러오는 데 실패했습니다.</Typography>;
 
     return (
@@ -56,7 +45,7 @@ const Exp = () => {
                     >
                         퀘스트 항목
                     </Typography>
-                    <Box className={styles.iconWrapper} onClick={handleOpenQuestModal}>
+                    <Box className={styles.iconWrapper} onClick={() => handleOpenQuestModal(true)}>
                         <InfoIcon sx={{fontSize: "2rem"}}/>
                     </Box>
                 </Box>
@@ -74,7 +63,7 @@ const Exp = () => {
                     >
                         지난주 독서 성과
                     </Typography>
-                    <Box className={styles.iconWrapper} onClick={handleOpenBedgeModal}>
+                    <Box className={styles.iconWrapper} onClick={() => handleOpenBedgeModal(true)}>
                         <InfoIcon sx={{fontSize: "2rem"}}/>
                     </Box>
                 </Box>
@@ -109,8 +98,8 @@ const Exp = () => {
                     </Box>
                 </Box>
             </Box>
-            <QuestInfoModal open={openQuestModal} onClose={handleCloseQuestModal} />
-            <BedgeInfoModal open={openBedgeModal} onClose={handleCloseBedgeModal} />
+            <QuestInfoModal open={openQuestModal} onClose={() => handleOpenQuestModal(false)} />
+            <BedgeInfoModal open={openBedgeModal} onClose={() => handleOpenBedgeModal(false)} />
         </Box>
     );
 };

--- a/bovo_client/src/pages/myPage/MyPage.jsx
+++ b/bovo_client/src/pages/myPage/MyPage.jsx
@@ -88,7 +88,7 @@ const MyPage = () => {
                     {userData?.level || 1}
                 </Typography>
             </Box>
-            <Container className={styles.expBarContainer}>
+            <Box className={styles.expBarContainer}>
                 <Box className={styles.expBarWrapper}>
                     <LinearProgress
                         variant="determinate"
@@ -119,8 +119,8 @@ const MyPage = () => {
                         /100
                     </Typography>
                 </Box>
-            </Container>
-            <Container className={styles.rpContainer}>
+            </Box>
+            <Box className={styles.rpContainer}>
                 <Box className={styles.rpHeader}>
                     <Typography 
                         className={styles.rpTitle}
@@ -178,7 +178,7 @@ const MyPage = () => {
                         </Box>
                     </Box>
                 </Box>
-            </Container>
+            </Box>
             <MenuList onLogout={handleLogoutModal} />
             {isLogout && <LogoutModal handleLogout={handleLogout}/>}
         </Container>

--- a/bovo_client/src/pages/myPage/MyPage.module.css
+++ b/bovo_client/src/pages/myPage/MyPage.module.css
@@ -110,6 +110,7 @@
 .rpTitle {
     width: 8.25rem;
     height: 100%;
+    padding-left: 1rem;
     display: flex;
     align-items: center;
     justify-self: center;
@@ -118,6 +119,7 @@
 .rpLink {
     width: 6.875rem;
     height: 2rem;
+    padding-right: 1rem;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/bovo_client/src/pages/myPage/MyPage.module.css
+++ b/bovo_client/src/pages/myPage/MyPage.module.css
@@ -93,8 +93,6 @@
 
 /* 독서 성과 관련 CSS */
 .rpContainer {
-    width: 33.75rem;
-    height: 15.625;
     margin-bottom: 3.75rem;
     display: flex;
     flex-direction: column;

--- a/bovo_client/src/pages/myProfile/MyProfile.jsx
+++ b/bovo_client/src/pages/myProfile/MyProfile.jsx
@@ -51,7 +51,7 @@ const MyProfile = () => {
     };
 
     if (isLoading) return <p>로딩 중...</p>;
-    if (isError) return <p>{error}</p>;
+    if (isError) return <p>{error?.message || "오류가 발생했습니다."}</p>;
 
     return (
         <Container className={styles.myProfileContainer}>

--- a/bovo_client/src/pages/myProfile/MyProfile.jsx
+++ b/bovo_client/src/pages/myProfile/MyProfile.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'; // PropTypes 임포트
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -11,7 +10,7 @@ import { useMyProfileQuery } from '../../api/UserApi';
 import { withdraw } from '../../api/AccountManager.js';
 import bedgeImages from '../../constant/BedgeImg.js';
 
-// MyProfile 페이지지
+// MyProfile 페이지
 const MyProfile = () => {
     const navigate = useNavigate();
     // 회원 탈퇴 모달 상태 관리
@@ -20,7 +19,8 @@ const MyProfile = () => {
     const { data: userData, isLoading, isError, error } = useMyProfileQuery();
 
     // ✅ 뱃지 이미지 가져오기
-    const userMedalSrc = bedgeImages.find((item) => item.key === userData?.medal)?.src;
+    const foundMedal = bedgeImages.find((item) => item.key === userData?.medal);
+    const userMedalSrc = foundMedal ? foundMedal.src : null;
 
     // 회원 탈퇴 모달 열기
     const openWithdrawModal = () => {
@@ -91,15 +91,9 @@ const MyProfile = () => {
                 </Button>
             </Box>
             { isWithdrawModalOpen && 
-                <WithdrawModal open={openWithdrawModal} onClose={closeWithdrawModal} handleWithdraw={handleWithdraw}/>}
+                <WithdrawModal isOpen={isWithdrawModalOpen} onClose={closeWithdrawModal} handleWithdraw={handleWithdraw}/>}
         </Container>
     );
-};
-
-// props 타입 정의
-ProfileInfoItem.propTypes = {
-    title: PropTypes.string.isRequired, // title은 string 타입이고 필수 props
-    content: PropTypes.node.isRequired, // content는 string 또는 JSX 요소(ReactNode) 가능
 };
 
 export default MyProfile;

--- a/bovo_client/src/pages/myProfileEdit/MyProfileEdit.jsx
+++ b/bovo_client/src/pages/myProfileEdit/MyProfileEdit.jsx
@@ -13,6 +13,35 @@ import LoadingSpinner from "../../components/loadingSpinner/LoadingSpinner";
 import { useNavigate } from "react-router-dom";
 
 
+// 공통 textfield sx 속성(style)
+const commonTextFieldSx = {
+    backgroundColor: "#E8F1F6",
+    width: "100%",
+    height: "2.5rem",
+    "& input": {
+      display: "flex",
+      alignItems: "center",
+      fontSize: "1.75rem",
+      height: "2.5rem",
+      padding: "0 1rem",
+    },
+    "& fieldset": { border: "none" },
+};
+
+// textfield 제목 sx 속성(style)
+const inputTitleSx = {
+    fontSize: "1.75rem",
+    fontWeight: "bold",
+    textAlign: "center",
+    marginLeft: "1rem",
+};
+
+// error 문구 sx 속성(style)
+const errorTextSx = {
+    fontSize: "1.75rem",
+    textAlign: "right",
+};
+
 const MyProfileEdit = () => {
     const navigate = useNavigate(); // ✅ useNavigate 추가
     const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
@@ -104,12 +133,7 @@ const MyProfileEdit = () => {
                     <Box className={styles.inputBox}>
                         <Typography
                             className={styles.inputTitle} 
-                            sx={{
-                                fontSize: "1.75rem", 
-                                fontWeight: "bold",
-                                textAlign: "center",
-                                marginLeft: "1rem"
-                            }}
+                            sx={inputTitleSx}
                         >
                             닉네임
                         </Typography>
@@ -121,26 +145,14 @@ const MyProfileEdit = () => {
                             {...register('nickname', validationRules.nickname)}
                             error={!!errors.nickname}
                             onBlur={() => handleBlur("nickname")}
-                            sx={{
-                                backgroundColor: "#E8F1F6",
-                                width: "100%",
-                                height: "2.5rem",  // ✅ 입력창 높이 조정
-                                "& input": {
-                                    display: "flex",
-                                    alignItems: "center", // ✅ Y축 중앙 정렬
-                                    fontSize: "1.75rem",
-                                    height: "2.5rem", 
-                                    padding: "0 1rem", // ✅ 내부 여백 제거
-                                },
-                                "& fieldset": { border: "none" }, // ✅ 아웃라인 제거
-                            }}
+                            sx={commonTextFieldSx}
                         />
                     </Box>
                     {errors.nickname && (
                         <Typography 
                             className={styles.errorText} 
                             color="error"
-                            sx={{ fontSize: "1.75rem", textAlign: "right" }}
+                            sx={errorTextSx}
                         >
                             {errors.nickname ? errors.nickname.message : "\u00A0"}
                         </Typography>
@@ -150,12 +162,7 @@ const MyProfileEdit = () => {
                     <Box className={styles.inputBox}>
                         <Typography
                             className={styles.inputTitle}
-                            sx={{
-                                fontSize: "1.75rem",
-                                fontWeight: "bold",
-                                textAlign: "center",
-                                marginLeft: "1rem"
-                            }}
+                            sx={inputTitleSx}
                         >
                             새 비밀번호
                         </Typography>
@@ -167,26 +174,14 @@ const MyProfileEdit = () => {
                             InputProps={{ autoComplete: "new-password" }}
                             error={!!errors.password}
                             onBlur={() => handleBlur("password")}
-                            sx={{
-                                backgroundColor: "#E8F1F6",
-                                width: "100%",
-                                height: "2.5rem",  // ✅ 입력창 높이 조정
-                                "& input": {
-                                    display: "flex",
-                                    alignItems: "center", // ✅ Y축 중앙 정렬
-                                    fontSize: "1.75rem",
-                                    height: "2.5rem", 
-                                    padding: "0 1rem", // ✅ 내부 여백 제거
-                                },
-                                "& fieldset": { border: "none" }, // ✅ 아웃라인 제거
-                            }}
+                            sx={commonTextFieldSx}
                         />
                     </Box>
                     {errors.password && (
                             <Typography 
                                 className={styles.errorText}
                                 color="error" 
-                                sx={{ fontSize: "1.75rem", textAlign: "right" }}
+                                sx={errorTextSx}
                             >
                                 {errors.password ? errors.password.message : "\u00A0"}
                             </Typography>
@@ -196,12 +191,7 @@ const MyProfileEdit = () => {
                     <Box className={styles.inputBox}>
                         <Typography
                             className={styles.inputTitle}
-                            sx={{
-                                fontSize: "1.75rem",
-                                fontWeight: "bold",
-                                textAlign: "center",
-                                marginLeft: "1rem"
-                            }}
+                            sx={inputTitleSx}
                         >
                             비밀번호 확인
                         </Typography>
@@ -213,26 +203,14 @@ const MyProfileEdit = () => {
                             {...register("confirmPassword", validationRules.confirmPassword(getValues))}
                             error={!!errors.confirmPassword}
                             onBlur={() => handleBlur("confirmPassword")}
-                            sx={{
-                                backgroundColor: "#E8F1F6",
-                                width: "100%",
-                                height: "2.5rem",  // ✅ 입력창 높이 조정
-                                "& input": {
-                                    display: "flex",
-                                    alignItems: "center", // ✅ Y축 중앙 정렬
-                                    fontSize: "1.75rem",
-                                    height: "2.5rem", 
-                                    padding: "0 1rem", // ✅ 내부 여백 제거
-                                },
-                                "& fieldset": { border: "none" }, // ✅ 아웃라인 제거
-                            }}
+                            sx={commonTextFieldSx}
                         />
                     </Box>
                     {errors.confirmPassword && (
                             <Typography
                                 className={styles.errorText} 
                                 color="error" 
-                                sx={{ fontSize: "1.75rem", textAlign: "right" }}
+                                sx={errorTextSx}
                             >
                                 {errors.confirmPassword ? errors.confirmPassword.message : "\u00A0"}
                             </Typography>

--- a/bovo_client/src/pages/myProfileEdit/MyProfileEdit.jsx
+++ b/bovo_client/src/pages/myProfileEdit/MyProfileEdit.jsx
@@ -216,40 +216,23 @@ const MyProfileEdit = () => {
                             </Typography>
                     )}
                 </Box>
-                {!isPending ? (
-                    <Button 
-                        className={styles.editBtn}
-                        type="submit"
-                        sx={{
-                            borderRadius: "1.5625rem",
-                            backgroundColor: "#BDE5F1",
-                            fontSize: "2.1875rem",
-                            color: "#FFFFFF",
-                            "&.Mui-disabled": {  // ✅ 비활성화 시 글자색 강제 설정
-                                color: "#FFFFFF",
-                                backgroundColor: "#ccc", // 배경색도 유지
-                                opacity: 1, // 기본적으로 흐려지는 효과 제거
-                            }
-                        }}
-                        disabled={!isValid}
-                    >
-                        확인
-                    </Button>
-                ) : (
-                    <Button 
-                        className={styles.editBtn}
-                        type="button"
-                        sx={{
-                            borderRadius: "1.5625rem",
-                            backgroundColor: "#D9D9D9",
-                            fontSize: "2.1875rem",
-                            color: "#FFFFFF",
-                        }}
-                        disabled={true}
-                    >
-                        전송 중...
-                    </Button>
-                )}
+                <Button 
+                    className={styles.editBtn}
+                    type={isPending ? "button" : "submit"}
+                    sx={{
+                        borderRadius: "1.5625rem",
+                        backgroundColor: "#BDE5F1",
+                        fontSize: "2.1875rem",
+                        color: "#FFFFFF",
+                        "&.Mui-disabled": {  // ✅ 비활성화 시 글자색 강제 설정
+                            backgroundColor: "#D9D9D9", // 배경색도 유지
+                            opacity: 1, // 기본적으로 흐려지는 효과 제거
+                        }
+                    }}
+                    disabled={isPending || !isValid}
+                >
+                    {isPending ? "전송 중..." : "확인"}
+                </Button>
             </form>
             <ProfileBottomSheet 
                 open={bottomSheetOpen} 

--- a/bovo_client/src/pages/serviceInfo/ServiceInfo.jsx
+++ b/bovo_client/src/pages/serviceInfo/ServiceInfo.jsx
@@ -10,7 +10,7 @@ const ServiceInfo = () => {
             <Box className={styles.logoBox}>
                 <img src={logo} alt="logo" />
             </Box>
-            <Container className={styles.infoContentContainer}>
+            <Box className={styles.infoContentContainer}>
                 <Box className={styles.versionInfo}>
                     <Typography sx={{ fontSize: "1.75rem" }} fontWeight="bold">
                         버전 정보
@@ -82,7 +82,7 @@ const ServiceInfo = () => {
                         2. 법적 의무가 있는 경우, 해당 기간 동안 보관 후 삭제
                     </Typography>
                 </Box>
-            </Container>
+            </Box>
         </Container>
     );
 };


### PR DESCRIPTION
1. MyPage 관련 Refactoring
- MyPage 독서성과 style 변화 => width, height 제거
- menuList key값을 index 대신 제목으로 설정
- MenuItem 관련 constant 디렉토리 상수로 추가(텍스트와 매칭)

2. MyProfile 페이지 관련 Refactoring
- 회원탈퇴 modal관련 props 변화(함수와 연결되었던 open 속성을 isOpen이란 boolean으로 변경)

3. MyProfileEdit 페이지 관련 Refactoring
- useForm 훅함수 관련 onSubmit mode로 변경(rerendering 변경)
- sx 속성 별도 변수에 할당, 중복 코드 제거

4. Exp 페이지 관련 Refactoring
- infoModal 관련 열고 닫는 함수 하나로 축약
- 미션 관련 constant 디렉토리에 별도로 mission key 분리(=> 기존 switch 방식으로 매칭됬던 방식을 객체의 text 매칭으로 변경)
- questButton style을 별도 파일로 분리하여 속성 할당