### PR TITLE
[Resolve] : 독서 토론방(채팅) 및 독서 토론방 만들기 페이지 문제 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,4 +450,21 @@ https://velog.io/@herjun802/Websocket-%EC%97%B0%EA%B2%B0-%EC%8B%A4%ED%8C%A8-%EB%
 > 해당 문제 해결 관련 설명 글<br> 
 https://velog.io/@herjun802/%EB%B9%84%EB%8F%99%EA%B8%B0-%ED%95%A8%EC%88%98%EC%9D%98-awaitwith-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0
 
+### 2025.06.11 ~ 06.12 독서 기록 공유 모달의 이벤트 버블링 현상 억제와 aria-hidden 해결(by 이영섭)
+#### 1. 독서 기록 공유 모달의 이벤트 버블링 현상 억제
+
+기존 독서 기록 공유 모달에서는 Checkbox 체크시 Accordion의 확장/축소 이벤트가 발생<br>
+이에 따라 MemoCheckbox라는 별도의 컴포넌트로 분리를 통해 해결<br>
+> 해당 문제 해결 관련 설명 글<br> 
+https://velog.io/@herjun802/%EC%9D%B4%EB%B2%A4%ED%8A%B8-%EB%B2%84%EB%B8%94%EB%A7%81event-bubbling-%ED%98%84%EC%83%81%EA%B3%BC-%EC%96%B5%EC%A0%9C
+
+
+#### 2. aria-hidden 경고 해결
+
+자손 요소에 focus가 유지되는 상태에서 부모요소에 aria-hidden이 적용됨으로써 브라우저 콘솔에 접근성 문제에 대한 에러 발생<br>
+이에 따라<br>
+(1) 독서 기록 공유 모달의 dialog와 같은 경우 disableRestoreFocus prop 사용<br>
+(2) 독서 토론방 만들기 페이지의 DatePicker의 경우 body태그로 focus가 이동하도록 만들어 자동적으로 DatePicker의 focus를 잃게 만드는 커스텀 함수를 적용<br>
+
+
 [맨 위로](#top)

--- a/bovo_client/src/components/forum/memoCheckbox/MemoCheckbox.jsx
+++ b/bovo_client/src/components/forum/memoCheckbox/MemoCheckbox.jsx
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+import Checkbox from '@mui/material/Checkbox';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+
+const MemoCheckbox = ({ checked, onChange }) => {
+    // 이 컴포넌트에서 모든 체크박스 관련 이벤트 처리를 담당
+    const handleClick = (e) => {
+        // ✅ 핵심: 체크박스 자체의 클릭 이벤트만 처리하고,
+        // 이 이벤트가 AccordionSummary로 버블링되지 않도록 여기서 명확하게 막습니다.
+        // 이렇게 하면 상위 컴포넌트(TemplateListItem)의 AccordionSummary는
+        // 체크박스 클릭에 대해 아무것도 알지 못하게 됩니다.
+        e.stopPropagation(); 
+    };
+
+    const handleChange = (e) => {
+        // 체크박스의 onChange 이벤트는 여기서 최종적으로 처리
+        // 부모에게 변경된 checked 상태만 전달
+        onChange(e.target.checked);
+    };
+
+    return (
+        <Checkbox
+            checked={checked}
+            onClick={handleClick} // 클릭 이벤트 버블링 방지
+            onChange={handleChange} // 실제 체크 상태 변경 처리
+            icon={<CheckBoxOutlineBlankIcon sx={{ fontSize: "2rem" }} />}
+            checkedIcon={<CheckBoxIcon sx={{ fontSize: "2rem", color: "#739CD4" }} />}
+        />
+    );
+};
+
+MemoCheckbox.propTypes = {
+    checked: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+};
+
+export default MemoCheckbox;

--- a/bovo_client/src/components/forum/readingShareModal/ReadingShareModal.jsx
+++ b/bovo_client/src/components/forum/readingShareModal/ReadingShareModal.jsx
@@ -72,7 +72,8 @@ const ReadingShareModal = ({
         <Dialog 
             open={open} 
             onClose={onClose} 
-            fullWidth 
+            fullWidth
+            disableRestoreFocus 
             sx={{
                 "& .MuiDialog-paper": {
                   width: "36.5625rem",

--- a/bovo_client/src/components/forum/templateListItem/TemplateListItem.jsx
+++ b/bovo_client/src/components/forum/templateListItem/TemplateListItem.jsx
@@ -3,30 +3,18 @@ import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
-import Checkbox from "@mui/material/Checkbox";
 import Typography from "@mui/material/Typography";
-import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
-import CheckBoxIcon from "@mui/icons-material/CheckBox";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import styles from "./TemplateListItem.module.css";
 import { memo, useState } from "react";
+import MemoCheckbox from "../memoCheckbox/MemoCheckbox";
 
 const TemplateListItem = ({ checked, handleCheckboxChange, memo }) => {
     const [expanded, setExpanded] = useState(false);
 
-    const handleAccordionChange = (panel) => (event, isExpanded) => {
+    const handleAccordionChange = (event, isExpanded) => {
         // Accordion이 열리거나 닫히는 동작을 제어
         setExpanded(isExpanded);
-    };
-
-    const handleCheckboxChangeWithPrevent = (e) => {
-        e.stopPropagation(); // 클릭 이벤트가 Accordion에 전달되지 않도록 막기
-        handleCheckboxChange(e.target.checked); // **체크박스 상태 변경** (변경된 부분)
-    };
-
-    const handleAccordionSummaryClick = (e) => {
-        // 클릭 이벤트가 AccordionSummary에만 전파되도록
-        e.stopPropagation(); 
     };
 
     return (
@@ -37,18 +25,18 @@ const TemplateListItem = ({ checked, handleCheckboxChange, memo }) => {
                 transition: "background-color 0.3s ease", // 부드러운 배경색 변경 효과
             }}
         >
-            <Accordion expanded={expanded} onChange={handleAccordionChange("panel1")}>
+            <Accordion expanded={expanded} onChange={handleAccordionChange}>
                 <AccordionSummary
                     expandIcon={<ExpandMoreIcon sx={{ fontSize: "2.625rem" }} />} // 화살표 아이콘
                     aria-controls="panel1a-content"
                     id="panel1a-header"
-                    onClick={handleAccordionSummaryClick} // 화살표 클릭 시만 열림/닫힘
+                    // ✅ 이제 AccordionSummary의 onClick 핸들러는 필요 없습니다.
+                    // MemoCheckbox에서 이미 stopPropagation을 처리했기 때문입니다.
+                    // AccordionSummary 클릭 시 Accordion 토글은 onChange를 통해 자연스럽게 작동합니다.
                 >
-                    <Checkbox
-                        checked={checked}
-                        onChange={handleCheckboxChangeWithPrevent}
-                        icon={<CheckBoxOutlineBlankIcon sx={{ fontSize: "2rem" }} />}
-                        checkedIcon={<CheckBoxIcon sx={{ fontSize: "2rem", color: "#739CD4" }} />}
+                    <MemoCheckbox 
+                        checked={checked} 
+                        onChange={handleCheckboxChange} // ✅ handleCheckboxChange는 부모로부터 받은 함수 그대로 사용
                     />
                     <Typography
                         sx={{

--- a/bovo_client/src/pages/forumMake/ForumMake.jsx
+++ b/bovo_client/src/pages/forumMake/ForumMake.jsx
@@ -196,6 +196,15 @@ const ForumMake = () => {
         }
     };
 
+    // 날짜 선택 모달이 닫힐 때 포커스를 이동시키는 함수
+    const handleDatePickerClose = () => {
+        // DatePicker 입력 필드에서 포커스를 제거 (blur 처리)하거나
+        // 다른 의미 있는 요소 (예: 다음 폼 필드나 제출 버튼)로 포커스를 옮길 수 있습니다.
+        // 여기서는 body에 포커스를 줘서 포커스를 날리는 방식을 사용합니다.
+        // 또는 특정 버튼이나 텍스트 필드로 포커스를 명시적으로 옮길 수도 있습니다.
+        document.body.focus();
+    };
+
     return (
         <form className={styles.forumMakeContainer} onSubmit={handleSubmit(onSubmit, onError)}>
             {book ? (
@@ -319,9 +328,9 @@ const ForumMake = () => {
                                 slotProps={{
                                     textField: {
                                         error: !!error,
-                                        inputProps: { 'aria-hidden': 'false' },
                                     }
                                 }}
+                                onClose={handleDatePickerClose}
                             />
                         )}
                     />
@@ -359,9 +368,9 @@ const ForumMake = () => {
                                 slotProps={{
                                     textField: {
                                         error: !!error,
-                                        inputProps: { 'aria-hidden': 'false' },
                                     }
                                 }}
+                                onClose={handleDatePickerClose}
                             />
                         )}
                     />


### PR DESCRIPTION
1. 독서 토론방(채팅) 내 독서 기록 공유 모달의 이벤트 버블링 현상 억제 및 aria-hidden 경고 해결
- Checkbox를 별도의 컴포넌트로 분리
- Dialog에 disableRestoreFocus prop 적용(aria-hidden 경고)

2.  독서토론방 만들기 페이지의 DatePicker 관련 aria-hidden 경고 해결